### PR TITLE
Note write access. Allow overriding user on release. Add docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+MAKEFLAGS += --warn-undefined-variables
+.SHELLFLAGS := -eux -o pipefail -c
+SHELL=/bin/bash
+
+GITHUB_USER ?= thbishop
+
 all: clean test build
 
 binaries: clean fmt test
@@ -21,7 +27,7 @@ fmt:
 
 release:
 	@echo "==> Releasing"
-	@script/release
+	@script/release $(GITHUB_USER)
 
 test: fmt vet
 	@echo "==> Running tests."

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ if you're on OSX.
 ## Usage
 
 Create a [github token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
-with `repo:status` scope and export it as an env var:
+with `repo:status` scope and write access to your repository and export it as an env var:
 ```sh
 export GITHUB_TOKEN=1234
 ```

--- a/README.md
+++ b/README.md
@@ -51,5 +51,14 @@ If needed, a proxy can be configured using environment variables:
 * Make sure tests pass
 * Send a pull request and I'll get it integrated
 
+## Build and release
+
+Note: this personal access token needs repo scope.
+
+```
+make
+GITHUB_TOKEN=<personal access token> make release [GITHUB_USER=<user>]
+```
+
 ## LICENSE
 See [LICENSE](LICENSE)

--- a/script/release
+++ b/script/release
@@ -3,7 +3,17 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-GITHUB_USER=thbishop
+usage(){
+	echo "Usage: $0 <github user>"
+	exit 1
+}
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+#passed from make
+GITHUB_USER=$1
 PROJECT_NAME=github-commit-status
 
 create_release() {


### PR DESCRIPTION
- Note write access is required for the user
  - it's not particularly obvious from the github docs, and you just get the helpful 404
- Allow overriding user on release
  - many orgs uncomfortable pulling binaries from uncontrolled sources
- Add docs
  - basic steps to build and release

Thanks for your work @thbishop !

I didn't update version.go as I haven't changed the go code. Hashes should be the same.

